### PR TITLE
feat: enable gobble gums during shop round

### DIFF
--- a/scripts/zm/zombies_rougelike.gsc
+++ b/scripts/zm/zombies_rougelike.gsc
@@ -28,13 +28,6 @@ REGISTER_SYSTEM_EX( "zombies_rougelike", &__init__, &__main__, undefined )
 function __init__(){
 }
 
-function bgb_machine_trigger_update_prompt_wrapper(player) {
-    // self.stub.trigger_target.base_cost is what's used later as the base_cost in function_6c7a96b4
-    // This prints 5000... proving that self.stub.trigger_target.base_cost is correct, yet the hintstring is still incorrect
-    IPrintLnBold(self.stub.trigger_target.base_cost);
-    return bgb_machine::bgb_machine_trigger_update_prompt(player);
-}
-
 function __main__(){
     debug_mode = true;
     level waittill("initial_blackscreen_passed");
@@ -62,7 +55,6 @@ function __main__(){
     foreach(bgb_machine in level.bgb_machines)
     {
         bgb_machine thread bgb_machine::hide_bgb_machine(0);
-        bgb_machine.unitrigger_stub.prompt_and_visibility_func = &bgb_machine_trigger_update_prompt_wrapper;
     }
 
     zombie_utility::set_zombie_var("zombie_move_speed_multiplier", 10, false, 2);

--- a/scripts/zm/zombies_rougelike.gsc
+++ b/scripts/zm/zombies_rougelike.gsc
@@ -33,6 +33,8 @@ function __main__(){
     level waittill("initial_blackscreen_passed");
     IPrintLnBold("Welcome to Zombies Rougelike v0.0.0!");
 
+    // This must be set to 0 to get SOE, DE, and The Giant bgb hintstrings to work
+    level.var_42792b8b = 0;
     level.func_override_wallbuy_prompt = &disable_wallbuy_purchase;
 
     foreach(player in level.players)

--- a/scripts/zm/zombies_rougelike.gsc
+++ b/scripts/zm/zombies_rougelike.gsc
@@ -28,6 +28,13 @@ REGISTER_SYSTEM_EX( "zombies_rougelike", &__init__, &__main__, undefined )
 function __init__(){
 }
 
+function bgb_machine_trigger_update_prompt_wrapper(player) {
+    // self.stub.trigger_target.base_cost is what's used later as the base_cost in function_6c7a96b4
+    // This prints 5000... proving that self.stub.trigger_target.base_cost is correct, yet the hintstring is still incorrect
+    IPrintLnBold(self.stub.trigger_target.base_cost);
+    return bgb_machine::bgb_machine_trigger_update_prompt(player);
+}
+
 function __main__(){
     debug_mode = true;
     level waittill("initial_blackscreen_passed");
@@ -55,9 +62,8 @@ function __main__(){
     foreach(bgb_machine in level.bgb_machines)
     {
         bgb_machine thread bgb_machine::hide_bgb_machine(0);
+        bgb_machine.unitrigger_stub.prompt_and_visibility_func = &bgb_machine_trigger_update_prompt_wrapper;
     }
-    level.bgb_machines = [];
-
 
     zombie_utility::set_zombie_var("zombie_move_speed_multiplier", 10, false, 2);
 
@@ -109,6 +115,10 @@ function init_shop()
         level waittill("fire_sale_on");
     }
     array::thread_all( level.chests, &chest_think );
+    foreach(bgb_machine in level.bgb_machines)
+    {
+        bgb_machine.base_cost = 5000;
+    }
 
     IPrintLnBold("You have " + duration + " seconds to use the shop and go to the mystery box!");
     level notify("zombies_rougelike_shop_start");


### PR DESCRIPTION
Currently blocked by not being able to update the price in the hintstring